### PR TITLE
feat: add /count and /echo dynamic pages

### DIFF
--- a/src/handlers/count.rs
+++ b/src/handlers/count.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use axum::response::Html;
+use axum::routing::{MethodRouter, get};
+
+use crate::content::Page;
+use crate::view;
+
+// /count — a visit counter, rendered per request. Shared mutable runtime state
+// (an atomic) that the static pages can't hold; the number climbs on refresh.
+// Ephemeral: resets when the process restarts (redeploy / scale-to-zero). The
+// counter lives in this closure, so each `route()` call gets its own.
+pub fn route(pages: Arc<Vec<Page>>) -> MethodRouter {
+    let counter = Arc::new(AtomicU64::new(0));
+    get(move || {
+        // fetch_add returns the previous value; +1 (saturating, to satisfy the
+        // arithmetic-side-effects lint) is this visit's count.
+        let count = counter.fetch_add(1, Ordering::Relaxed).saturating_add(1);
+        let html = view::count_page(count, pages.as_slice());
+        async move { Html(html) }
+    })
+}

--- a/src/handlers/echo.rs
+++ b/src/handlers/echo.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use axum::extract::Request;
+use axum::response::Html;
+use axum::routing::{MethodRouter, get};
+
+use crate::content::Page;
+use crate::view;
+
+// /echo — reflects the request back (method, path, headers), rendered
+// server-side. The static pages ignore the request entirely; this reads it.
+pub fn route(pages: Arc<Vec<Page>>) -> MethodRouter {
+    get(move |req: Request| {
+        let method = req.method().as_str().to_owned();
+        let path = req.uri().path().to_owned();
+        let headers: Vec<(String, String)> = req
+            .headers()
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.as_str().to_owned(),
+                    v.to_str().unwrap_or("<binary>").to_owned(),
+                )
+            })
+            .collect();
+        let html = view::echo_page(&method, &path, &headers, pages.as_slice());
+        async move { Html(html) }
+    })
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,1 +1,3 @@
 pub mod assets;
+pub mod count;
+pub mod echo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod view;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Discover pages once at startup; a malformed page fails here, loudly.
     let pages = Arc::new(content::load().map_err(std::io::Error::other)?);
-    let app = routes::app(pages.as_slice());
+    let app = routes::app(&pages);
 
     // Render (and most PaaS) inject the HTTP port via $PORT; fall back for local dev.
     // SSH binds a high port locally (privileged ports need root); a host maps :22 to it.

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::{
     Router,
     extract::Request,
@@ -8,16 +10,18 @@ use axum::{
 };
 
 use crate::content::Page;
-use crate::handlers::assets;
+use crate::handlers::{assets, count, echo};
 use crate::view;
 
-// Build the router from the discovered pages: one route per page (pre-rendered
-// at startup), the stylesheet, and a 404 fallback. Adding a page needs no edit
-// here — it appears once its file is in content/pages/.
-pub fn app(pages: &[Page]) -> Router {
+// Build the router: one route per discovered content page (pre-rendered at
+// startup), the stylesheet, two dynamic (per-request) pages, and a 404 fallback.
+// Adding a *content* page needs no edit here — it appears once its file is in
+// content/pages/. The dynamic pages carry their own logic in handlers/; here we
+// just register them, like the stylesheet.
+pub fn app(pages: &Arc<Vec<Page>>) -> Router {
     let mut router = Router::new();
-    for page in pages {
-        let html = view::render_page(page, pages);
+    for page in pages.iter() {
+        let html = view::render_page(page, pages.as_slice());
         router = router.route(
             &page.path,
             get(move || {
@@ -27,9 +31,11 @@ pub fn app(pages: &[Page]) -> Router {
         );
     }
 
-    let not_found = view::not_found(pages);
+    let not_found = view::not_found(pages.as_slice());
     router
         .route("/style.css", get(assets::stylesheet))
+        .route("/count", count::route(Arc::clone(pages)))
+        .route("/echo", echo::route(Arc::clone(pages)))
         .fallback(move || {
             let html = not_found.clone();
             async move { (StatusCode::NOT_FOUND, Html(html)) }
@@ -65,7 +71,50 @@ mod tests {
     type TestResult = Result<(), Box<dyn std::error::Error>>;
 
     fn test_app() -> Result<Router, String> {
-        Ok(app(&crate::content::load()?))
+        Ok(app(&Arc::new(crate::content::load()?)))
+    }
+
+    async fn body_string(res: Response) -> Result<String, Box<dyn std::error::Error>> {
+        let bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await?;
+        Ok(String::from_utf8(bytes.to_vec())?)
+    }
+
+    #[tokio::test]
+    async fn count_increments_across_requests() -> TestResult {
+        // Router clones share the same atomic counter, so two hits count 1 then 2.
+        let app = test_app()?;
+        let first = app
+            .clone()
+            .oneshot(Request::builder().uri("/count").body(Body::empty())?)
+            .await?;
+        let second = app
+            .oneshot(Request::builder().uri("/count").body(Body::empty())?)
+            .await?;
+
+        assert!(
+            body_string(first)
+                .await?
+                .contains("served <strong>1</strong> time")
+        );
+        assert!(
+            body_string(second)
+                .await?
+                .contains("served <strong>2</strong> times")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn echo_reflects_the_request() -> TestResult {
+        let req = Request::builder()
+            .uri("/echo")
+            .header("user-agent", "test-agent")
+            .body(Body::empty())?;
+        let body = body_string(test_app()?.oneshot(req).await?).await?;
+
+        assert!(body.contains("/echo"));
+        assert!(body.contains("test-agent"));
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -55,6 +55,47 @@ pub fn render_page(page: &Page, pages: &[Page]) -> String {
     .into_string()
 }
 
+// /count — the visit counter, rendered fresh each request. Demonstrates
+// server-side state: the number changes on refresh, which no static page can.
+pub fn count_page(count: u64, pages: &[Page]) -> String {
+    shell(
+        "Count",
+        &html! {
+            h1 { "Visits" }
+            p {
+                "This page has been served "
+                strong { (count) }
+                @if count == 1 { " time" } @else { " times" }
+                " since the server last started."
+            }
+            p { "Refresh — the number goes up. The static pages can’t do that; they’re baked once at startup." }
+        },
+        &nav_links(pages),
+    )
+    .into_string()
+}
+
+// /echo — the request reflected back, rendered server-side. Demonstrates
+// request-awareness: static pages ignore the request entirely.
+pub fn echo_page(method: &str, path: &str, headers: &[(String, String)], pages: &[Page]) -> String {
+    shell(
+        "Echo",
+        &html! {
+            h1 { "Echo" }
+            p { "The server rendered this table from your request:" }
+            table {
+                tr { th { "Method" } td { (method) } }
+                tr { th { "Path" } td { (path) } }
+                @for (name, value) in headers {
+                    tr { th { (name) } td { (value) } }
+                }
+            }
+        },
+        &nav_links(pages),
+    )
+    .into_string()
+}
+
 // The 404 document, sharing the same shell and nav.
 pub fn not_found(pages: &[Page]) -> String {
     shell(

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,3 +1,6 @@
+// ponytail: all HTML views share this file. Fine at this size; split into a
+// view/ submodule (or co-locate per-page views with their handlers) if it grows
+// unwieldy — trigger and options tracked in issue #8.
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use pulldown_cmark::{Parser, html::push_html};
 


### PR DESCRIPTION
## What

Two pure-Rust, per-request pages alongside the Markdown-discovered static ones — a demonstration of server-side rendering the static pages structurally can't do.

- **`/count`** — visit counter (`Arc<AtomicU64>`), climbs on refresh. Holds runtime **state** static pages can't. Ephemeral: resets on process restart (redeploy / scale-to-zero).
- **`/echo`** — reflects the **request** (method, path, headers) back. Static pages ignore the request; this reads it.

## Shape

- Handler logic lives in `handlers/count.rs` + `handlers/echo.rs` as `route(pages) -> MethodRouter` factories, matching the existing `assets::stylesheet` precedent. `routes.rs` `app()` stays pure wiring — just registers them.
- `app()` now takes the `Arc<Vec<Page>>` that `main` already owns, so the handlers can share it for nav rendering (one-line ripple to `main` + test helper).
- Renders reuse `view::shell` — same nav and stylesheet as content pages.
- HTTP-only: SSH nav is content-page-derived, so these don't appear there. Not in the nav bar either (nav generates from content `Page`s) — reachable by URL.

## Tests

- `/count` increments 1→2 across shared router clones.
- `/echo` reflects a sent header.

Verified live: `/count` went `1 time → 2 times → 3 times`; `/echo` reflected real `host`/`user-agent`/`accept` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)